### PR TITLE
Use `<dialog>` and `showModal()` for Modals

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -7,8 +7,6 @@
 | Z-Index | Entity | Path |
 | --: | --- | --- |
 | 1031 | nprogress { bar, spinner }  | [`/node_modules/nprogress/nprogress.css>#nprogress .bar`](/node_modules/nprogress/nprogress.css), [`/node_modules/nprogress/nprogress.css>#nprogress .spinner`](/node_modules/nprogress/nprogress.css) |
-| 255 | modal | [`modal.scss>.modal`](/src/lib/stylesheets/modal.scss) |
-| 254 | modal bg | [`layout.scss>.modal-bg`](/src/lib/stylesheets/layout.scss) |
 | 253 | header, header2 | [`header.scss>header`](/src/lib/stylesheets/header/header.scss), [`header.scss>#header2`](/src/lib/stylesheets/header/header.scss) |
 | 252 | header bg | [`header.scss>#header-bg`](/src/lib/stylesheets/header/header.scss) |
 | -1 | bg | [`layout.scss>main::before`](/src/lib/stylesheets/layout.scss) |

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -3,11 +3,11 @@
 	import Socials from './Socials.svelte';
 	import LangSwitcher from './LangSwitcher.svelte';
 
-	import { isContactModalOpened, isDrawerMenuOpened } from '$lib/scripts/stores';
+	import { isDrawerMenuOpened } from '$lib/scripts/stores';
 	import { COPYRIGHT } from '$lib/scripts/variables';
 </script>
 
-<footer inert={$isDrawerMenuOpened || $isContactModalOpened}>
+<footer inert={$isDrawerMenuOpened}>
 	<p class="copyright">{COPYRIGHT}</p>
 	<div class="socials"><Socials /></div>
 	<div class="lang-btn"><LangSwitcher /></div>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,6 +1,7 @@
 <!-- © 2022 REVATI -->
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
+	import { fly } from 'svelte/transition';
 
 	export let open: Writable<boolean>;
 	export let title: string | null = null;
@@ -37,29 +38,31 @@
 	class="modal"
 	style="min-width: min({minWidth}px, 100vw - 8px);"
 >
-	<div class="modal-content">
-		{#if title !== null}
-			<h1>{title}</h1>
-		{/if}
-		<slot />
-		<button on:click={close}>
-			<!--
-				Google Material Symbols and Icons - Close
-				https://fonts.google.com/icons?selected=Material+Symbols+Outlined:close:FILL@0;wght@400;GRAD@200;opsz@24&icon.query=close&icon.size=24&icon.color=%23e8eaed
-				This icon is licensed under the Apache License Version 2.0: https://github.com/google/material-design-icons/blob/master/README.md
-			-->
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				height="24px"
-				viewBox="0 -960 960 960"
-				width="24px"
-				fill="#e8eaed"
-				><path
-					d="m252-176-74-76 227-228-227-230 74-76 229 230 227-230 74 76-227 230 227 228-74 76-227-230-229 230Z"
-				/></svg
-			>
-		</button>
-	</div>
+	{#if $open}
+		<div class="modal-content" transition:fly|global={{ y: -64, duration: 240 }}>
+			{#if title !== null}
+				<h1>{title}</h1>
+			{/if}
+			<slot />
+			<button on:click={close}>
+				<!--
+					Google Material Symbols and Icons - Close
+					https://fonts.google.com/icons?selected=Material+Symbols+Outlined:close:FILL@0;wght@400;GRAD@200;opsz@24&icon.query=close&icon.size=24&icon.color=%23e8eaed
+					This icon is licensed under the Apache License Version 2.0: https://github.com/google/material-design-icons/blob/master/README.md
+				-->
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					height="24px"
+					viewBox="0 -960 960 960"
+					width="24px"
+					fill="#e8eaed"
+					><path
+						d="m252-176-74-76 227-228-227-230 74-76 229 230 227-230 74 76-227 230 227 228-74 76-227-230-229 230Z"
+					/></svg
+				>
+			</button>
+		</div>
+	{/if}
 </dialog>
 
 <style lang="scss">

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -34,9 +34,8 @@
 	on:close={close}
 	bind:this={dialog}
 	class="modal"
-	style="min-width: min({minWidth}px, 100vw - 29px);"
 >
-	<div class="modal-content">
+	<div class="modal-content" style="min-width: min({minWidth}px, 100vw - 29px);">
 		{#if title !== null}
 			<h1>{title}</h1>
 		{/if}

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -13,7 +13,7 @@
 
 	let dialog: HTMLDialogElement;
 	open.subscribe((isOpen) => {
-		if (dialog != undefined && dialog !== null) {
+		if (dialog !== undefined && dialog !== null) {
 			if (isOpen) dialog.showModal();
 			else dialog.close();
 		}

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -9,7 +9,7 @@
 	 *
 	 * But it will be `100vw - 29px` if it is bigger than `100vw - 29px`.
 	 */
-	export let minWidth: number = 358;
+	export let minWidth: number = 382;
 
 	let dialog: HTMLDialogElement;
 	open.subscribe((isOpen) => {
@@ -25,6 +25,7 @@
 </script>
 
 <!-- Is the `<dialog>` element really not a non-interactive element? -->
+<!-- And `8px` in the `style` attribute is the sum of the maximum border width of the `<dialog>` element. -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <dialog
@@ -34,8 +35,9 @@
 	on:close={close}
 	bind:this={dialog}
 	class="modal"
+	style="min-width: min({minWidth}px, 100vw - 8px);"
 >
-	<div class="modal-content" style="min-width: min({minWidth}px, 100vw - 29px);">
+	<div class="modal-content">
 		{#if title !== null}
 			<h1>{title}</h1>
 		{/if}

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,6 +1,6 @@
 <!-- © 2022 REVATI -->
 <script lang="ts">
-	import type { Writable } from "svelte/store";
+	import type { Writable } from 'svelte/store';
 
 	export let open: Writable<boolean>;
 	export let title: string | null = null;
@@ -16,7 +16,7 @@
 		if (dialog != undefined && dialog !== null) {
 			if (isOpen) dialog.showModal();
 			else dialog.close();
-		};
+		}
 	});
 
 	function close() {
@@ -28,7 +28,9 @@
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <dialog
-	on:click={(e) => { if (e.target === dialog) close() }}
+	on:click={(e) => {
+		if (e.target === dialog) close();
+	}}
 	on:close={close}
 	bind:this={dialog}
 	class="modal"

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,8 +1,8 @@
 <!-- © 2022 REVATI -->
 <script lang="ts">
-	import { fly } from 'svelte/transition';
-	import { closeAllModals } from '$lib/scripts/util';
+	import type { Writable } from "svelte/store";
 
+	export let open: Writable<boolean>;
 	export let title: string | null = null;
 	/**
 	 * The minimum width of the modal. (`px`)
@@ -10,38 +10,54 @@
 	 * But it will be `100vw - 29px` if it is bigger than `100vw - 29px`.
 	 */
 	export let minWidth: number = 358;
-	/** Whether the modal does not have a bloom effect. */
-	export let doesNotHaveBloom: boolean = false;
+
+	let dialog: HTMLDialogElement;
+	open.subscribe((isOpen) => {
+		if (dialog != undefined && dialog !== null) {
+			if (isOpen) dialog.showModal();
+			else dialog.close();
+		};
+	});
+
+	function close() {
+		open.set(false);
+	}
 </script>
 
-<div
+<!-- Is the `<dialog>` element really not a non-interactive element? -->
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<dialog
+	on:click={(e) => { if (e.target === dialog) close() }}
+	on:close={close}
+	bind:this={dialog}
 	class="modal"
-	class:no-bloom={doesNotHaveBloom}
 	style="min-width: min({minWidth}px, 100vw - 29px);"
-	transition:fly|global={{ y: -64, duration: 240 }}
 >
-	{#if title !== null}
-		<h1>{title}</h1>
-	{/if}
-	<slot />
-	<button on:click={closeAllModals}>
-		<!--
-			Google Material Symbols and Icons - Close
-			https://fonts.google.com/icons?selected=Material+Symbols+Outlined:close:FILL@0;wght@400;GRAD@200;opsz@24&icon.query=close&icon.size=24&icon.color=%23e8eaed
-			This icon is licensed under the Apache License Version 2.0: https://github.com/google/material-design-icons/blob/master/README.md
-		-->
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			height="24px"
-			viewBox="0 -960 960 960"
-			width="24px"
-			fill="#e8eaed"
-			><path
-				d="m252-176-74-76 227-228-227-230 74-76 229 230 227-230 74 76-227 230 227 228-74 76-227-230-229 230Z"
-			/></svg
-		>
-	</button>
-</div>
+	<div class="modal-content">
+		{#if title !== null}
+			<h1>{title}</h1>
+		{/if}
+		<slot />
+		<button on:click={close}>
+			<!--
+				Google Material Symbols and Icons - Close
+				https://fonts.google.com/icons?selected=Material+Symbols+Outlined:close:FILL@0;wght@400;GRAD@200;opsz@24&icon.query=close&icon.size=24&icon.color=%23e8eaed
+				This icon is licensed under the Apache License Version 2.0: https://github.com/google/material-design-icons/blob/master/README.md
+			-->
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				height="24px"
+				viewBox="0 -960 960 960"
+				width="24px"
+				fill="#e8eaed"
+				><path
+					d="m252-176-74-76 227-228-227-230 74-76 229 230 227-230 74 76-227 230 227 228-74 76-227-230-229 230Z"
+				/></svg
+			>
+		</button>
+	</div>
+</dialog>
 
 <style lang="scss">
 	@use '$lib/stylesheets/modal';

--- a/src/lib/components/header/Contact.svelte
+++ b/src/lib/components/header/Contact.svelte
@@ -1,24 +1,17 @@
 <!-- © 2022 REVATI -->
 <script lang="ts">
-	import Modal from '../Modal.svelte';
-
-	import { isContactModalOpened as isOpened } from '$lib/scripts/stores';
 	import { _ } from 'svelte-i18n';
 	import { SOCIALS } from '$lib/scripts/variables';
 </script>
 
-{#if $isOpened}
-	<Modal title="CONTACT US">
-		<p>
-			{$_('contact.desc')}<br />
-			{$_('contact.note.0')}<br />
-			{$_('contact.note.1')}
-		</p>
-		<div class="mail-btn-container">
-			<a href="mailto:{SOCIALS.email}" draggable="false">{$_('contact.button')}</a>
-		</div>
-	</Modal>
-{/if}
+<p>
+	{$_('contact.desc')}<br />
+	{$_('contact.note.0')}<br />
+	{$_('contact.note.1')}
+</p>
+<div class="mail-btn-container">
+	<a href="mailto:{SOCIALS.email}" draggable="false">{$_('contact.button')}</a>
+</div>
 
 <style lang="scss">
 	@use '$lib/stylesheets/variables/mixin' as *;

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -8,7 +8,11 @@
 
 	import { browser } from '$app/environment';
 	import { HEADER_ITEMS, NON_SECTION_ITEMS } from '$lib/scripts/data/HEADER_ITEMS';
-	import { isContactModalOpen, isDrawerMenuOpened, isHamburgerButtonEnabled } from '$lib/scripts/stores';
+	import {
+		isContactModalOpen,
+		isDrawerMenuOpened,
+		isHamburgerButtonEnabled
+	} from '$lib/scripts/stores';
 	import { _ } from 'svelte-i18n';
 	import { COPYRIGHT } from '$lib/scripts/variables';
 	import { page } from '$app/stores';
@@ -73,11 +77,7 @@
 
 <Modal open={isContactModalOpen} title="CONTACT US"><Contact /></Modal>
 
-<div
-	id="header2"
-	class:open={$isDrawerMenuOpened}
-	inert={!$isDrawerMenuOpened}
->
+<div id="header2" class:open={$isDrawerMenuOpened} inert={!$isDrawerMenuOpened}>
 	<div class="socials">
 		<Socials
 			style="

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -1,16 +1,16 @@
 <!-- © 2022 REVATI -->
 <script lang="ts">
 	import HbBtn from './HamburgerButton.svelte';
-	import Socials from '../Socials.svelte';
-	import LangSwitcher from '../LangSwitcher.svelte';
+	import Modal from '$lib/components/Modal.svelte';
+	import Socials from '$lib/components/Socials.svelte';
+	import LangSwitcher from '$lib/components/LangSwitcher.svelte';
 	import Contact from './Contact.svelte';
 
 	import { browser } from '$app/environment';
 	import { HEADER_ITEMS, NON_SECTION_ITEMS } from '$lib/scripts/data/HEADER_ITEMS';
-	import { isDrawerMenuOpened, isHamburgerButtonEnabled } from '$lib/scripts/stores';
+	import { isContactModalOpen, isDrawerMenuOpened, isHamburgerButtonEnabled } from '$lib/scripts/stores';
 	import { _ } from 'svelte-i18n';
 	import { COPYRIGHT } from '$lib/scripts/variables';
-	import { isContactModalOpened } from '$lib/scripts/stores';
 	import { page } from '$app/stores';
 
 	$: url = $page.url;
@@ -42,7 +42,7 @@
 
 <div id="header-bg" class:visible={$isDrawerMenuOpened} />
 
-<header class:open={$isDrawerMenuOpened} inert={$isContactModalOpened}>
+<header class:open={$isDrawerMenuOpened}>
 	<nav>
 		<a href="/" draggable="false" tabindex="-1"><span title={$_('header.back')} /></a>
 		<HbBtn />
@@ -50,7 +50,7 @@
 			{#each HEADER_ITEMS as item}
 				{#if item === 'contact'}
 					<li class="item-contact">
-						<button class:active={false} on:click={() => isContactModalOpened.update(() => true)}
+						<button class:active={false} on:click={() => isContactModalOpen.set(true)}
 							>CONTACT</button
 						>
 					</li>
@@ -71,12 +71,12 @@
 	</nav>
 </header>
 
-<Contact />
+<Modal open={isContactModalOpen} title="CONTACT US"><Contact /></Modal>
 
 <div
 	id="header2"
 	class:open={$isDrawerMenuOpened}
-	inert={!$isDrawerMenuOpened || $isContactModalOpened}
+	inert={!$isDrawerMenuOpened}
 >
 	<div class="socials">
 		<Socials

--- a/src/lib/components/home/Teams.svelte
+++ b/src/lib/components/home/Teams.svelte
@@ -23,9 +23,11 @@
 
 	let gearsAndSettingsModalContent: {
 		playerName: string;
-		gearsAndSettings: GearsAndSettingsType
+		gearsAndSettings: GearsAndSettingsType;
 	} | null = null;
-	isGearsAndSettingsModalOpen.subscribe((isOpen) => { if (!isOpen) gearsAndSettingsModalContent = null });
+	isGearsAndSettingsModalOpen.subscribe((isOpen) => {
+		if (!isOpen) gearsAndSettingsModalContent = null;
+	});
 
 	const LOCK_ICON: {
 		kind: IconKind;

--- a/src/lib/components/home/Teams.svelte
+++ b/src/lib/components/home/Teams.svelte
@@ -179,10 +179,17 @@
 					<li class="gears-and-settings">
 						<button
 							on:click={() => {
-								gearsAndSettingsModalContent = {
-									playerName: memberName,
-									gearsAndSettings
-								};
+								// The `gearsAndSettings` variable is already guaranteed to be not `undefined` by the `#if` block,
+								// but we exclude `undefined` again with a ternary operator to avoid ESLint errors.
+								// The `gearsAndSettingsModalContent` variable will never be assigned `null` here,
+								// because the button is not rendered if the `gearsAndSettings` variable is `undefined`.
+								gearsAndSettingsModalContent =
+									gearsAndSettings !== undefined
+										? {
+												playerName: memberName,
+												gearsAndSettings
+											}
+										: null;
 								isGearsAndSettingsModalOpen.set(true);
 							}}
 							class="gears-and-settings-btn"

--- a/src/lib/components/home/coaching/Coaches.svelte
+++ b/src/lib/components/home/coaching/Coaches.svelte
@@ -74,7 +74,7 @@
 
 	@include sp {
 		ul {
-			width: min(504px, 90vw);
+			width: min(504px, 100%);
 		}
 	}
 </style>

--- a/src/lib/components/home/coaching/Coaches.svelte
+++ b/src/lib/components/home/coaching/Coaches.svelte
@@ -36,7 +36,9 @@
 	ul {
 		display: flex;
 		width: 672px;
+		margin: 0 auto;
 		margin-top: 38px;
+		margin-bottom: 22px;
 		padding: 0;
 		gap: 36px 0;
 		flex-wrap: wrap;

--- a/src/lib/components/home/coaching/Coaching.svelte
+++ b/src/lib/components/home/coaching/Coaching.svelte
@@ -5,7 +5,7 @@
 	import Coaches from './Coaches.svelte';
 
 	import { _ } from 'svelte-i18n';
-	import { isFeesModalOpened, isCoachesModalOpened } from '$lib/scripts/stores';
+	import { isFeesModalOpen, isCoachesModalOpen } from '$lib/scripts/stores';
 
 	$: modalTitles = {
 		fees: $_('coaching.fees'),
@@ -27,10 +27,8 @@
 
 <div class="buttons">
 	<div>
-		<button on:click={() => isFeesModalOpened.update(() => true)}>{modalTitles.fees}</button>
-		{#if $isFeesModalOpened}
-			<Modal title={modalTitles.fees} minWidth={485} doesNotHaveBloom><Fees /></Modal>
-		{/if}
+		<button on:click={() => isFeesModalOpen.set(true)}>{modalTitles.fees}</button>
+		<Modal open={isFeesModalOpen} title={modalTitles.fees} minWidth={485}><Fees /></Modal>
 	</div>
 	<div>
 		<a
@@ -49,10 +47,8 @@
 		</a>
 	</div>
 	<div>
-		<button on:click={() => isCoachesModalOpened.update(() => true)}>{modalTitles.coaches}</button>
-		{#if $isCoachesModalOpened}
-			<Modal title={modalTitles.coaches} doesNotHaveBloom><Coaches /></Modal>
-		{/if}
+		<button on:click={() => isCoachesModalOpen.set(true)}>{modalTitles.coaches}</button>
+		<Modal open={isCoachesModalOpen} title={modalTitles.coaches}><Coaches /></Modal>
 	</div>
 </div>
 

--- a/src/lib/scripts/stores.ts
+++ b/src/lib/scripts/stores.ts
@@ -1,8 +1,7 @@
 // © 2022 REVATI
 
-import { writable, type Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
-import type { GearsAndSettings } from './types';
 import { toggleScrollPrevention } from '$lib/scripts/util';
 
 export const isDrawerMenuOpened = writable(false);
@@ -16,20 +15,14 @@ isDrawerMenuOpened.subscribe((isOpened) => {
 
 export const isHamburgerButtonEnabled = writable(false);
 
-export const isContactModalOpened = writable(false);
-isContactModalOpened.subscribe(updateScrollPrevention);
-export const isFeesModalOpened = writable(false);
-isFeesModalOpened.subscribe(updateScrollPrevention);
-export const isCoachesModalOpened = writable(false);
-isCoachesModalOpened.subscribe(updateScrollPrevention);
-export const gearsAndSettingsModalState: Writable<{
-	isOpened: boolean;
-	content: {
-		playerName: string;
-		gearsAndSettings: GearsAndSettings;
-	} | null;
-}> = writable({ isOpened: false, content: null });
-gearsAndSettingsModalState.subscribe(({ isOpened }) => updateScrollPrevention(isOpened));
+export const isContactModalOpen = writable(false);
+isContactModalOpen.subscribe(updateScrollPrevention);
+export const isFeesModalOpen = writable(false);
+isFeesModalOpen.subscribe(updateScrollPrevention);
+export const isCoachesModalOpen = writable(false);
+isCoachesModalOpen.subscribe(updateScrollPrevention);
+export const isGearsAndSettingsModalOpen = writable(false);
+isGearsAndSettingsModalOpen.subscribe(updateScrollPrevention);
 
 function updateScrollPrevention(v: boolean) {
 	if (browser) toggleScrollPrevention(v);

--- a/src/lib/scripts/stores.ts
+++ b/src/lib/scripts/stores.ts
@@ -1,6 +1,6 @@
 // © 2022 REVATI
 
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import { browser } from '$app/environment';
 import { toggleScrollPrevention } from '$lib/scripts/util';
 
@@ -16,7 +16,7 @@ isDrawerMenuOpened.subscribe((isOpened) => {
 export const isHamburgerButtonEnabled = writable(false);
 
 export const isContactModalOpen = writable(false);
-isContactModalOpen.subscribe(updateScrollPrevention);
+isContactModalOpen.subscribe((isOpen) => updateScrollPrevention(isOpen || get(isDrawerMenuOpened)));
 export const isFeesModalOpen = writable(false);
 isFeesModalOpen.subscribe(updateScrollPrevention);
 export const isCoachesModalOpen = writable(false);

--- a/src/lib/scripts/util.ts
+++ b/src/lib/scripts/util.ts
@@ -1,12 +1,5 @@
 // © 2022 REVATI
 
-import {
-	isContactModalOpened,
-	isFeesModalOpened,
-	isCoachesModalOpened,
-	gearsAndSettingsModalState
-} from '$lib/scripts/stores';
-
 /**
  * Adds a specified class to specified elements when they are scrolled into view.
  *
@@ -101,12 +94,4 @@ export function calcAge(birthday: Date) {
 /** Pads a number with zeros. */
 export function zeroPad(num: number, len: number) {
 	return num.toString().padStart(len, '0');
-}
-
-/** Closes all the modals. */
-export function closeAllModals() {
-	isContactModalOpened.update(() => false);
-	isFeesModalOpened.update(() => false);
-	isCoachesModalOpened.update(() => false);
-	gearsAndSettingsModalState.update(() => ({ isOpened: false, content: null }));
 }

--- a/src/lib/stylesheets/layout.scss
+++ b/src/lib/stylesheets/layout.scss
@@ -15,13 +15,6 @@
 	}
 }
 
-.modal-bg {
-	position: fixed;
-	inset: 0;
-	background-color: #000000aa;
-	z-index: 254;
-}
-
 main::before {
 	content: '';
 	$dark: rgba($secondary-color, 0.75);

--- a/src/lib/stylesheets/modal.scss
+++ b/src/lib/stylesheets/modal.scss
@@ -4,35 +4,27 @@
 @use '$lib/stylesheets/variables/mixin' as *;
 
 $secondary-color: #ccfbff;
-$bloom-color: #63f2ff;
 
 .modal {
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
 	max-height: 85%;
 	margin: auto;
+	color: inherit;
 	background-color: #122426;
 	border: 4px solid $secondary-color;
-	padding: 18px 32px;
-	padding-bottom: 34px;
+	padding: 0;
 	border-radius: 6px;
-	$bloom-color-large: rgba($bloom-color, 0.08);
-	$bloom-color-small: rgba($secondary-color, 0.2);
-	filter: drop-shadow(0 0 128px $bloom-color-large) drop-shadow(0 0 28px $bloom-color-small);
 	overflow: scroll;
 	scrollbar-color: $old-primary-color transparent;
 	scrollbar-width: thin;
-	z-index: 255;
 
-	@include sp {
-		filter: drop-shadow(0 0 32px $bloom-color-large) drop-shadow(0 0 14px $bloom-color-small);
+	&::backdrop {
+		background: #000000aa;
 	}
+}
 
-	&.no-bloom {
-		filter: none;
-	}
+.modal-content {
+	padding: 18px 32px;
+	padding-bottom: 34px;
 }
 
 h1 {
@@ -40,7 +32,7 @@ h1 {
 	font-size: 34px;
 	font-weight: 900;
 	margin: 16px 0;
-	filter: drop-shadow(0 0 14px rgba($bloom-color, 0.5));
+	filter: drop-shadow(0 0 14px #63f2ff80);
 
 	&::before,
 	&::after {

--- a/src/lib/stylesheets/modal.scss
+++ b/src/lib/stylesheets/modal.scss
@@ -6,7 +6,6 @@
 $secondary-color: #ccfbff;
 
 .modal {
-	max-height: 85%;
 	margin: auto;
 	color: inherit;
 	background-color: #122426;
@@ -23,6 +22,7 @@ $secondary-color: #ccfbff;
 }
 
 .modal-content {
+	max-height: 85%;
 	padding: 18px 32px;
 	padding-bottom: 34px;
 }
@@ -63,10 +63,13 @@ svg {
 
 @include sp {
 	.modal {
+		border: 2px solid $secondary-color;
+	}
+
+	.modal-content {
 		min-width: 224px;
 		max-width: 90vw;
 		padding: 12px 12px;
-		border: 2px solid $secondary-color;
 	}
 
 	h1 {

--- a/src/lib/stylesheets/modal.scss
+++ b/src/lib/stylesheets/modal.scss
@@ -6,6 +6,7 @@
 $secondary-color: #ccfbff;
 
 .modal {
+	max-height: 85%;
 	margin: auto;
 	color: inherit;
 	background-color: #122426;
@@ -22,7 +23,6 @@ $secondary-color: #ccfbff;
 }
 
 .modal-content {
-	max-height: 85%;
 	padding: 18px 32px;
 	padding-bottom: 34px;
 }
@@ -63,12 +63,12 @@ svg {
 
 @include sp {
 	.modal {
+		min-width: 224px;
+		max-width: 90vw;
 		border: 2px solid $secondary-color;
 	}
 
 	.modal-content {
-		min-width: 224px;
-		max-width: 90vw;
 		padding: 12px 12px;
 	}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,10 +4,7 @@
 	import Footer from '$lib/components/Footer.svelte';
 
 	import { BREAKPOINT_HB } from '$lib/scripts/variables';
-	import {
-		isDrawerMenuOpened,
-		isHamburgerButtonEnabled
-	} from '$lib/scripts/stores';
+	import { isDrawerMenuOpened, isHamburgerButtonEnabled } from '$lib/scripts/stores';
 	import NProgress from 'nprogress';
 	import 'nprogress/nprogress.css';
 	import { navigating, page } from '$app/stores';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,15 +3,10 @@
 	import Header from '$lib/components/header/Header.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 
-	import { closeAllModals } from '$lib/scripts/util';
 	import { BREAKPOINT_HB } from '$lib/scripts/variables';
 	import {
-		isContactModalOpened,
 		isDrawerMenuOpened,
-		isFeesModalOpened,
-		isCoachesModalOpened,
-		isHamburgerButtonEnabled,
-		gearsAndSettingsModalState
+		isHamburgerButtonEnabled
 	} from '$lib/scripts/stores';
 	import NProgress from 'nprogress';
 	import 'nprogress/nprogress.css';
@@ -37,10 +32,6 @@
 
 		setVh001();
 		setMaxVh001();
-
-		document.addEventListener('keydown', (event) => {
-			if (event.key === 'Escape') closeAllModals();
-		});
 	}
 
 	// if (browser) {
@@ -78,8 +69,6 @@
 		maxVh1 = window.innerHeight;
 		document.documentElement.style.setProperty('--max-vh001', maxVh1 * 0.01 + 'px');
 	}
-
-	function empty() {} // eslint-disable-line @typescript-eslint/no-empty-function
 </script>
 
 <svelte:head>
@@ -120,13 +109,9 @@
 	<link rel="icon" href="/images/logos/revati/icon_180px_oxipng.png?v=3" />
 </svelte:head>
 
-{#if $isContactModalOpened || $isFeesModalOpened || $isCoachesModalOpened || $gearsAndSettingsModalState.isOpened}
-	<div class="modal-bg" on:click={closeAllModals} on:keypress={empty} role="none" />
-{/if}
-
 <Header />
 
-<main inert={$isDrawerMenuOpened || $isContactModalOpened}><slot /></main>
+<main inert={$isDrawerMenuOpened}><slot /></main>
 
 <Footer />
 


### PR DESCRIPTION
- ♻️♿ Re-implement all the modals with the `<dialog>` tag and the `HTMLDialogElement.showModal()` method [#154]
    - 🛠️ Adjusted the modal size
    - 🛠️ Changed the modal intro animations
    - 🛠️ Removed the modal outro animations
    - ✏️ Renamed all the Svelte stores for the modals from `is*Opened` to `is*Open` [aa8e5e768d4aef1cad8d39f9c2f8d2e409d41ec7]
    - 🛠️ The `Contact` component is no longer include the `Modal` component [aa8e5e768d4aef1cad8d39f9c2f8d2e409d41ec7]
    - ♻️ The `gearsAndSettingsModalState` store no longer has the modal data [aa8e5e768d4aef1cad8d39f9c2f8d2e409d41ec7]
    - ⚰️ Removed a utility function `closeAllModals` [938012e9c81176edcba2e569688d4ea12542f429]
