### PR TITLE
`ArticleId` Class for `ArticleMetadata` Type

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -128,7 +128,12 @@ Returns a list of the news articles.
 	- `published` (`boolean`) - Whether the article is published.
 	- `indexed` (`boolean`) - Whether the article is indexed.
 	- `title` (`string`) - The title of the article.
-	- `slug` (`string?`) - The slug of the article. Its type is an optional string but it always exists.
+	- `slug` (`object?`) - The slug of the article. Its type is an optional string but it always exists.
+        - `year` (`number`) - The year of the article.
+        - `month` (`number`) - The month of the article.
+        - `day` (`number`) - The day of the article.
+        - `no` (`number`) - The number of the article in the day.
+        - `text` (`string | null`) - The text of the article ID.
 
 #### Example
 

--- a/src/lib/components/news/ArticleCard.svelte
+++ b/src/lib/components/news/ArticleCard.svelte
@@ -1,16 +1,16 @@
 <!-- © 2022 REVATI -->
 <script lang="ts">
 	import type { ArticleMetadata, ArticleThumbnailImgFmts } from '$lib/scripts/types';
-	import { idToDate } from '$lib/scripts/util';
 	import { _, date as dateI18n } from 'svelte-i18n';
 
 	export let meta: ArticleMetadata;
 	export let thumbnailImgFmts: ArticleThumbnailImgFmts;
 	export let forceDesktopVerOnSemiNarrow = false;
 
-	const slug = meta.slug ?? 'unreachable';
+	const articleId = meta.slug!;
+	const slug = articleId.string;
 	const thumbnailImgFmt = thumbnailImgFmts[slug] ?? null;
-	const date = idToDate(slug);
+	const date = articleId.date;
 	let datePlus9h = new Date(date);
 	datePlus9h.setHours(datePlus9h.getHours() + 9);
 </script>

--- a/src/lib/scripts/ArticleId.ts
+++ b/src/lib/scripts/ArticleId.ts
@@ -21,9 +21,9 @@ export class ArticleId {
 	text: string | null;
 
 	/**
-     * @param slug - The slug of an article.
-     * `YYYYMMDD` or `YYYYMMDDNN` or `YYYYMMDD_text` or `YYYYMMDDNN_text` is expected.
-     */
+	 * @param slug - The slug of an article.
+	 * `YYYYMMDD` or `YYYYMMDDNN` or `YYYYMMDD_text` or `YYYYMMDDNN_text` is expected.
+	 */
 	constructor(slug: string);
 	constructor(value: ArticleId);
 

--- a/src/lib/scripts/ArticleId.ts
+++ b/src/lib/scripts/ArticleId.ts
@@ -1,5 +1,7 @@
 // © 2022 REVATI
 
+import { zeroPad } from '$lib/scripts/util';
+
 export class ArticleId {
 	/** The year of the article. */
 	year: number;
@@ -42,5 +44,16 @@ export class ArticleId {
 			this.no = arg.no;
 			this.text = arg.text;
 		}
+	}
+
+	/** Returns the slug string of the article. */
+	get string() {
+		const text = this.text;
+		return `${this.year}${zeroPad(this.month, 2)}${zeroPad(this.day, 2)}${1 < this.no ? zeroPad(this.no, 2) : ''}${text === null ? '' : '_' + text}`;
+	}
+
+	/** Returns the `Date` object of the article. */
+	get date() {
+		return new Date(this.year, this.month - 1, this.day);
 	}
 }

--- a/src/lib/scripts/ArticleId.ts
+++ b/src/lib/scripts/ArticleId.ts
@@ -19,17 +19,28 @@ export class ArticleId {
 	text: string | null;
 
 	/**
-	 * @param value - The slug of an article.
-	 * `YYYYMMDD` or `YYYYMMDDNN` or `YYYYMMDD_text` or `YYYYMMDDNN_text` is expected.
-	 */
-	constructor(value: string) {
-		let text: string;
-		[value, text] = value.split('_');
-		const no = parseInt(value.slice(8, 10));
-		this.year = parseInt(value.slice(0, 4));
-		this.month = parseInt(value.slice(4, 6));
-		this.day = parseInt(value.slice(6, 8));
-		this.no = isNaN(no) ? 1 : no;
-		this.text = text === undefined ? null : text;
+     * @param slug - The slug of an article.
+     * `YYYYMMDD` or `YYYYMMDDNN` or `YYYYMMDD_text` or `YYYYMMDDNN_text` is expected.
+     */
+	constructor(slug: string);
+	constructor(value: ArticleId);
+
+	constructor(arg: string | ArticleId) {
+		if (typeof arg === 'string') {
+			let text: string;
+			[arg, text] = arg.split('_');
+			const no = parseInt(arg.slice(8, 10));
+			this.year = parseInt(arg.slice(0, 4));
+			this.month = parseInt(arg.slice(4, 6));
+			this.day = parseInt(arg.slice(6, 8));
+			this.no = isNaN(no) ? 1 : no;
+			this.text = text === undefined ? null : text;
+		} else {
+			this.year = arg.year;
+			this.month = arg.month;
+			this.day = arg.day;
+			this.no = arg.no;
+			this.text = arg.text;
+		}
 	}
 }

--- a/src/lib/scripts/fetchers.ts
+++ b/src/lib/scripts/fetchers.ts
@@ -1,6 +1,7 @@
 // © 2022 REVATI
 
 import type { ArticleMetadata, ArticleThumbnailImgFmts } from '$lib/scripts/types';
+import { ArticleId } from '$lib/scripts/ArticleId';
 
 const ARTICLES = import.meta.glob('/articles/[0-9][0-9][0-9][0-9]/([1-9]|1[0-2])/*.md');
 
@@ -11,7 +12,7 @@ export async function fetchArticles() {
 		Object.entries(ARTICLES).map(async ([path, importArticle]) => {
 			const { metadata } = (await importArticle()) as { metadata: ArticleMetadata };
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			metadata.slug = path.split('/').pop()!.split('.')[0];
+			metadata.slug = new ArticleId(path.split('/').pop()!.split('.')[0]);
 			return metadata;
 		})
 	);
@@ -21,7 +22,7 @@ export async function fetchArticles() {
 
 	// Sort by newest.
 	articles.sort((a, b) => {
-		if (typeof a.slug === 'string' && typeof b.slug === 'string')
+		if (a.slug instanceof ArticleId && b.slug instanceof ArticleId)
 			return calcOrder(b.slug) - calcOrder(a.slug);
 		// unreachable
 		return 0;
@@ -30,8 +31,8 @@ export async function fetchArticles() {
 	return articles;
 }
 
-function calcOrder(slug: string) {
-	let n = parseInt(slug.split('_')[0]);
+function calcOrder(slug: ArticleId) {
+	let n = parseInt(slug.string.split('_')[0]);
 	// It is alignment for slugs without numbering.
 	n *= n < 100000000 ? 100 : 1;
 	return n;

--- a/src/lib/scripts/types.ts
+++ b/src/lib/scripts/types.ts
@@ -1,11 +1,14 @@
 // © 2022 REVATI
 
+import { ArticleId } from '$lib/scripts/ArticleId';
+
+/** The `slug` field will be provided if the instance was provided by the API. */
 export interface ArticleMetadata {
 	redirect?: string;
 	published: boolean;
 	indexed: boolean;
 	title: string;
-	slug?: string;
+	slug?: ArticleId;
 }
 
 export interface ArticleThumbnailImgFmts {

--- a/src/lib/scripts/util.ts
+++ b/src/lib/scripts/util.ts
@@ -1,7 +1,7 @@
 // © 2022 REVATI
 
-import type { ArticleMetadata } from "$lib/scripts/types";
-import { ArticleId } from "$lib/scripts/ArticleId";
+import type { ArticleMetadata } from '$lib/scripts/types';
+import { ArticleId } from '$lib/scripts/ArticleId';
 
 /**
  * Adds a specified class to specified elements when they are scrolled into view.

--- a/src/lib/scripts/util.ts
+++ b/src/lib/scripts/util.ts
@@ -1,5 +1,8 @@
 // © 2022 REVATI
 
+import type { ArticleMetadata } from "$lib/scripts/types";
+import { ArticleId } from "$lib/scripts/ArticleId";
+
 /**
  * Adds a specified class to specified elements when they are scrolled into view.
  *
@@ -97,4 +100,12 @@ export function zeroPad(num: number, len: number) {
  */
 export function updateVh001() {
 	document.documentElement.style.setProperty('--vh001', window.innerHeight * 0.01 + 'px');
+}
+
+/** Reconstructs the `ArticleId` instances of the `slug` field in the `ArticleMetadata` instance array. */
+export function reconstructIdsOfArticleMetadata(articles: ArticleMetadata[]) {
+	return articles.map((a) => {
+		if (a.slug !== undefined) a.slug = new ArticleId(a.slug);
+		return a;
+	});
 }

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -12,7 +12,9 @@ export const load: PageLoad = async ({
 	thumbnailImgFmts: ArticleThumbnailImgFmts;
 	division: string | null;
 }> => {
-	const articles: ArticleMetadata[] = reconstructIdsOfArticleMetadata(await (await fetch('/api/articles')).json());
+	const articles: ArticleMetadata[] = reconstructIdsOfArticleMetadata(
+		await (await fetch('/api/articles')).json()
+	);
 	const thumbnailImgFmts = await (await fetch('/api/articles/thumbnail-imgs')).json();
 
 	const division = url.searchParams.get('div');

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -2,6 +2,7 @@
 
 import type { PageLoad } from './$types';
 import type { ArticleMetadata, ArticleThumbnailImgFmts } from '$lib/scripts/types';
+import { reconstructIdsOfArticleMetadata } from '$lib/scripts/util';
 
 export const load: PageLoad = async ({
 	fetch,
@@ -11,7 +12,7 @@ export const load: PageLoad = async ({
 	thumbnailImgFmts: ArticleThumbnailImgFmts;
 	division: string | null;
 }> => {
-	const articles = await (await fetch('/api/articles')).json();
+	const articles: ArticleMetadata[] = reconstructIdsOfArticleMetadata(await (await fetch('/api/articles')).json());
 	const thumbnailImgFmts = await (await fetch('/api/articles/thumbnail-imgs')).json();
 
 	const division = url.searchParams.get('div');

--- a/src/routes/news/+page.ts
+++ b/src/routes/news/+page.ts
@@ -2,6 +2,7 @@
 
 import type { PageLoad } from './$types';
 import type { ArticleMetadata, ArticleThumbnailImgFmts } from '$lib/scripts/types';
+import { reconstructIdsOfArticleMetadata } from '$lib/scripts/util';
 
 export const load: PageLoad = async ({
 	fetch
@@ -9,7 +10,7 @@ export const load: PageLoad = async ({
 	articles: ArticleMetadata[];
 	thumbnailImgFmts: ArticleThumbnailImgFmts;
 }> => {
-	const articles = await (await fetch('/api/articles')).json();
+	const articles = reconstructIdsOfArticleMetadata(await (await fetch('/api/articles')).json());
 	const thumbnailImgFmts = await (await fetch('/api/articles/thumbnail-imgs')).json();
 	return { articles, thumbnailImgFmts };
 };


### PR DESCRIPTION
- ♻️ The `slug` field of the `ArticleMetadata` type now uses the `ArticleId` as its type  [#173]
    - ✨ The constructor of the `ArticleId` class now accepts a `string` or an `ArticleId` instance as an argument [371469ec7a901c8287b50d1c4fb9010ad8f2cc01]
    - ✨ Added two getters, `string` and `date`, to the `ArticleId` class [bd82f7b2cee6ce0f12cef96f06d1e01927d8ee04]
    - ✨ Implemented a utility function `reconstructIdsOfArticleMetadata` [5b856b08eac8f324b669fe644ee652615d2dc661]
    - 📚 Updated the specification document for the response body of the Articles API [bba0bc68572adb4716a3f6eefb2839698c911005]
