### PR TITLE
Fix invalid urls `/[object Object]` in `sitemap.xml`

### DIFF
--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -16,13 +16,14 @@ export const GET: RequestHandler = async ({ setHeaders }) => {
 
 async function body() {
 	const articles = (await fetchArticles())
-		.map(
-			(article) => `<url>
-        <loc>${SITE_URL}/news/articles/${article.slug}</loc>
+		.map((article) => {
+			const slug = article.slug?.string;
+			return `<url>
+        <loc>${SITE_URL}/news/articles/${slug}</loc>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
-    </url>`
-		)
+    </url>`;
+		})
 		.join('\n    ');
 
 	return `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- 🐛 The `sitemap.xml` had invalid URLs `/[object Object]` [#188]
